### PR TITLE
add support for public id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ desktop.ini
 .vs
 
 # Autodocs
+.directory
 _build
 .build
 .static

--- a/README.rst
+++ b/README.rst
@@ -68,21 +68,23 @@ Configuration
 -------------
 
 In order to use this SDK, you need to have an Auth Key as well as an
-Auth Key ID for a given Dragonchain ID. These can be loaded into the sdk
-in various ways, and are checked in the following order of precedence:
+Auth Key ID for a given Dragonchain ID. It is also strongly suggested that
+you supply an endpoint locally so that a remote service isn't called to
+automatically discover your dragonchain endpoint. These can be loaded into the
+sdk in various ways, and are checked in the following order of precedence:
 
 1. The ``dragonchain_sdk.client`` can be initialized with the parameters
-   ``dragonchain_id=<ID>``, ``auth_key=<KEY>``, and
-   ``auth_key_id=<KEY_ID>``
+   ``dragonchain_id=<ID>``, ``auth_key=<KEY>``,
+   ``auth_key_id=<KEY_ID>``, and ``endpoint=<URL>``
 
 2. The environment variables ``DRAGONCHAIN_ID``,
-   ``AUTH_KEY``, and ``AUTH_KEY_ID`` can be set
-   with the appropriate values
+   ``AUTH_KEY``, ``AUTH_KEY_ID``, and ``DRAGONCHAIN_ENDPOINT``,
+   can be set with the appropriate values
 
 3. An ini-style credentials file can be provided at
    ``~/.dragonchain/credentials`` (or on Windows:
-   ``%LOCALAPPDATA%\dragonchain\credentials``) where the section name is
-   the dragonchain id, with values for ``auth_key`` and ``auth_key_id``.
+   ``%LOCALAPPDATA%\dragonchain\credentials``) where the section name is the
+   dragonchain id, with values for ``auth_key``, ``auth_key_id``, and ``endpoint``.
    Additionally, you can supply a value for ``dragonchain_id`` in the
    ``default`` section to initialize the client for a specific chain
    without supplying an ID any other way
@@ -96,15 +98,17 @@ in various ways, and are checked in the following order of precedence:
    .. code:: ini
 
       [default]
-      dragonchain_id = 35a7371c-a20a-4830-9a59-5d654fcd0a4a
+      dragonchain_id = c2dffKwiGj6AGg4zHkNswgEcyHeQaGr4Cm5SzsFVceVv
 
-      [35a7371c-a20a-4830-9a59-5d654fcd0a4a]
+      [c2dffKwiGj6AGg4zHkNswgEcyHeQaGr4Cm5SzsFVceVv]
       auth_key_id = JSDMWFUJDVTC
       auth_key = n3hlldsFxFdP2De0yMu6A4MFRh1HGzFvn6rJ0ICZzkE
+      endpoint = https://35a7371c-a20a-4830-9a59-5d654fcd0a4a.api.dragonchain.com
 
-      [28567017-6412-44b6-80b2-12876fb3d4f5]
+      [28VhSgtPhwkhKBgmQSW6vrsir7quEYHdCjqsW6aAYbfrw]
       auth_key_id = OGNHGLYIFVUA
       auth_key = aS73Si7agvX9gfxnLMh6ack9DEuidKiwQxkqBudXl81
+      endpoint = https://28567017-6412-44b6-80b2-12876fb3d4f5.api.dragonchain.com
 
 
 Contributing

--- a/dragonchain_sdk/__init__.py
+++ b/dragonchain_sdk/__init__.py
@@ -13,7 +13,7 @@ from dragonchain_sdk.dragonchain_client import Client
 import logging
 
 __author__ = 'Dragonchain'
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 
 def set_stream_logger(name='dragonchain_sdk', level=logging.DEBUG, format_string=None):

--- a/dragonchain_sdk/configuration.py
+++ b/dragonchain_sdk/configuration.py
@@ -23,7 +23,7 @@ def get_dragonchain_id():
     """Get the dragonchain id if not provided. First checks environment, then configuration files
 
     Raises:
-        DragonchainIdentityNotFound if no dragonchain ID is found
+        DragonchainIdentityNotFound: if no dragonchain ID is found
 
     Returns:
         Default dragonchain id string if found
@@ -49,7 +49,7 @@ def get_endpoint(dragonchain_id: str):
         dragonchain_id (str): The dragonchain id to fetch the endpoint for
 
     Raises:
-        DragonchainIdentityNotFound if endpoint cannot be found
+        DragonchainIdentityNotFound: if endpoint cannot be found
 
     Returns:
         None, sets the class auth_key and auth_key_id instance variables
@@ -75,7 +75,7 @@ def get_credentials(dragonchain_id: str):
         dragonchain_id (str): The dragonchain id to fetch credentials keys for
 
     Raises:
-        DragonchainIdentityNotFound if credentials can't be found for a given chain
+        DragonchainIdentityNotFound: if credentials can't be found for a given chain
 
     Returns:
         Tuple of strings where index 0 is the auth_key_id and index 1 is the auth_key
@@ -129,7 +129,7 @@ def _get_endpoint_from_remote(dragonchain_id: str):
         dragonchain_id (str): The dragonchain id to get the endpoint for
 
     Raises:
-        MatchmakingException with any non-200 response from matchmaking, or any errors to communicate
+        MatchmakingException: with any non-200 response from matchmaking, or any errors to communicate
 
     Returns:
         String of endpoint from remote service if found

--- a/dragonchain_sdk/configuration.py
+++ b/dragonchain_sdk/configuration.py
@@ -1,0 +1,210 @@
+# Copyright 2019 Dragonchain, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import logging
+import configparser
+import requests
+from dragonchain_sdk import exceptions
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_dragonchain_id():
+    """Get the dragonchain id if not provided. First checks environment, then configuration files
+
+    Raises:
+        DragonchainIdentityNotFound if no dragonchain ID is found
+
+    Returns:
+        Default dragonchain id string if found
+    """
+    logger.debug('Checking if dragonchain_id is in the environment')
+    dragonchain_id = os.environ.get('DRAGONCHAIN_ID')
+    if not dragonchain_id:
+        logger.debug('dragonchain_id isn\'t in the environment, trying to load default from ini config file')
+        try:
+            # Check config ini file if ID isn't provided explicitly or in environment
+            config = configparser.ConfigParser()
+            config.read(_get_config_file_path())
+            dragonchain_id = config.get('default', 'dragonchain_id')
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            raise exceptions.DragonchainIdentityNotFound('Could not locate dragonchain_id.')
+    return dragonchain_id
+
+
+def get_endpoint(dragonchain_id: str):
+    """Get an endpoint for a dragonchain. First checks environment, then configuration files, then a remote service
+
+    Args:
+        dragonchain_id (str): The dragonchain id to fetch the endpoint for
+
+    Raises:
+        DragonchainIdentityNotFound if endpoint cannot be found
+
+    Returns:
+        None, sets the class auth_key and auth_key_id instance variables
+    """
+    endpoint = _get_endpoint_from_environment()
+    if endpoint:
+        return endpoint
+    logger.debug('Endpoint isn\'t in environment, trying to load from ini config file')
+    endpoint = _get_endpoint_from_file(dragonchain_id)
+    if endpoint:
+        return endpoint
+    logger.debug('Endpoint isn\'t in config file, trying to load from remote service')
+    try:
+        return _get_endpoint_from_remote(dragonchain_id)
+    except exceptions.MatchmakingException:
+        raise exceptions.DragonchainIdentityNotFound('Unable to locate dragonchain endpoint')
+
+
+def get_credentials(dragonchain_id: str):
+    """Get an auth_key/auth_key_id pair if not provided. First checks environment, then configuration files, then smart contract location
+
+    Args:
+        dragonchain_id (str): The dragonchain id to fetch credentials keys for
+
+    Raises:
+        DragonchainIdentityNotFound if credentials can't be found for a given chain
+
+    Returns:
+        Tuple of strings where index 0 is the auth_key_id and index 1 is the auth_key
+    """
+    auth_key_id, auth_key = _get_credentials_from_environment()
+    if bool(auth_key) and bool(auth_key_id):
+        return auth_key_id, auth_key
+    logger.debug('Credentials aren\'t in environment, trying to load from ini config file')
+    auth_key_id, auth_key = _get_credentials_from_file(dragonchain_id)
+    if bool(auth_key) and bool(auth_key_id):
+        return auth_key_id, auth_key
+    logger.debug('Credentials aren\'t in config file, trying to load as a smart contract')
+    auth_key_id, auth_key = _get_credentials_as_smart_contract()
+    if bool(auth_key) and bool(auth_key_id):
+        return auth_key_id, auth_key
+    raise exceptions.DragonchainIdentityNotFound('Unable to locate dragonchain authorization credentials')
+
+
+def _get_endpoint_from_environment():
+    """Attempt to get endpoint for a dragonchain from the environment variables
+
+    Returns:
+        String of endpoint from environment. Empty string if not found
+    """
+    logger.debug('Checking if Endpoint is in the environment')
+    return os.environ.get('DRAGONCHAIN_ENDPOINT') or ''
+
+
+def _get_endpoint_from_file(dragonchain_id: str):
+    """Attempt to get endpoint for a dragonchain from the configuration file
+
+    Args:
+        dragonchain_id (str): The dragonchain id to get the endpoint for
+
+    Returns:
+        String of endpoint from file. Empty string if not found
+    """
+    try:
+        # If both keys aren't in environment variables, check config file
+        config = configparser.ConfigParser()
+        config.read(_get_config_file_path())
+        return config.get(dragonchain_id, 'endpoint')
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return ''
+
+
+def _get_endpoint_from_remote(dragonchain_id: str):
+    """Attempt to get endpoint for a dragonchain from the configuration file
+
+    Args:
+        dragonchain_id (str): The dragonchain id to get the endpoint for
+
+    Raises:
+        MatchmakingException with any non-200 response from matchmaking, or any errors to communicate
+
+    Returns:
+        String of endpoint from remote service if found
+    """
+    try:
+        r = requests.get('https://matchmaking.api.dragonchain.com/registration/{}'.format(dragonchain_id), timeout=30)
+    except (requests.Timeout, requests.ConnectionError, requests.ConnectTimeout):
+        logger.exception('Could not contact matchmaking for dragonchain endpoint. Ensure internet is working properly.')
+        raise exceptions.MatchmakingException('Could not contact matchmaking')
+    except Exception:
+        logger.exception('Unexpected failure to make request with matchmaking')
+        raise exceptions.MatchmakingException('Unexpected failure to make request with matchmaking')
+    if r.status_code < 200 or r.status_code >= 300:
+        raise exceptions.MatchmakingException('Non-200 response from matchmaking. Status code {} with response: {}'.format(r.status_code, r.text))
+    try:
+        return r.json()['url']
+    except Exception:
+        raise exceptions.MatchmakingException('Unexpected response contents from matchmaking\n{}'.format(r.text))
+
+
+def _get_credentials_from_environment():
+    """Attempt to get credentials for a dragonchain from the environment
+
+    Returns:
+        Tuple of auth_key_id/auth_key of credentials from environment. Empty strings in tuple if not found
+    """
+    logger.debug('Checking if credentials are in the environment')
+    auth_key = os.environ.get('AUTH_KEY') or ''
+    auth_key_id = os.environ.get('AUTH_KEY_ID') or ''
+    return auth_key_id, auth_key
+
+
+def _get_credentials_from_file(dragonchain_id: str):
+    """Attempt to get credentials for a dragonchain from the credentials file
+
+    Args:
+        dragonchain_id (str): The dragonchain id to get the credentials for
+
+    Returns:
+        Tuple of auth_key_id/auth_key of credentials from environment. Empty strings in tuple if not found
+    """
+    try:
+        config = configparser.ConfigParser()
+        config.read(_get_config_file_path())
+        return config.get(dragonchain_id, 'auth_key_id'), config.get(dragonchain_id, 'auth_key')
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return '', ''
+
+
+def _get_credentials_as_smart_contract():
+    """Attempt to get credentials for a dragonchain from the standard location for a smart contract
+
+    Returns:
+        Tuple of auth_key_id/auth_key of credentials from environment. Empty strings in tuple if not found
+    """
+    try:
+        base_path = os.path.join(os.path.abspath(os.sep), 'var', 'openfaas', 'secrets')
+        auth_key = open(os.path.join(base_path, 'sc-{}-secret-key'.format(os.environ.get('SMART_CONTRACT_ID'))), 'r').read()
+        auth_key_id = open(os.path.join(base_path, 'sc-{}-auth-key-id'.format(os.environ.get('SMART_CONTRACT_ID'))), 'r').read()
+        return auth_key_id, auth_key
+    except (OSError, IOError, FileNotFoundError):
+        return '', ''
+
+
+def _get_config_file_path():
+    """Get the path for the credential file depending on the OS
+
+    Returns:
+        Python path-like object of the file path for the configuration file
+    """
+    if os.name == 'nt':
+        logger.debug('Windows OS detected')
+        path = os.path.join(os.path.expandvars('%LOCALAPPDATA%'), 'dragonchain', 'credentials')
+    else:
+        logger.debug('Posix OS detected')
+        path = os.path.join(os.path.expanduser("~"), '.dragonchain', 'credentials')
+    logger.debug('Credentials file path: {}'.format(path))
+    return path

--- a/dragonchain_sdk/credentials.py
+++ b/dragonchain_sdk/credentials.py
@@ -29,7 +29,7 @@ class Credentials(object):
         algorithm (str, optional): The hash algorithm to use with the HMAC authentication scheme (SHA256 | BLAKE2b512 | SHA3-256)
 
     Raises:
-        TypeError with bad parameter types
+        TypeError: with bad parameter types
 
     Returns:
         A new Credentials object.
@@ -66,7 +66,7 @@ class Credentials(object):
             algorithm (str): The algorithm to use. Valid options are BLAKE2b512, SHA256, or SHA3-256
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             None, sets the HMAC signing algorithm for this credential instance
@@ -85,7 +85,7 @@ class Credentials(object):
             algorithm (str): The algorithm to use. Valid options are BLAKE2b512, SHA256, or SHA3-256
 
         Raises:
-            NotImplementedError when provided algorithm is not supported
+            NotImplementedError: when provided algorithm is not supported
 
         Returns
             hashlib interface compatible hash method
@@ -106,7 +106,7 @@ class Credentials(object):
             unencoded_bytes (bytes): Python bytes object to encode
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             String of the base64 encoded bytes
@@ -122,8 +122,8 @@ class Credentials(object):
             input_data (bytes or str): input to process
 
         Raises:
-            TypeError with bad parameter types
-            ValueError with bad parameter values
+            TypeError: with bad parameter types
+            ValueError: with bad parameter values
 
         Returns:
             bytes object representation of input

--- a/dragonchain_sdk/dragonchain_client.py
+++ b/dragonchain_sdk/dragonchain_client.py
@@ -21,7 +21,7 @@ class Client(object):
     """Construct a new ``Client`` object
 
     Args:
-        dragonchain_id (str): The ID of the chain to connect to.
+        dragonchain_id (str, optional): The ID of the chain to connect to.
         auth_key_id (str, optional): The authorization key ID
         auth_key (str, optional): The authorization key
         endpoint (str, optional): The endpoint of the Dragonchain
@@ -31,12 +31,12 @@ class Client(object):
     Returns:
         A new Dragonchain client.
     """
-    def __init__(self, dragonchain_id=None, auth_key_id=None, auth_key=None, endpoint=None, verify=True, algorithm='SHA256'):
+    def __init__(self, dragonchain_id: str = None, auth_key_id: str = None, auth_key: str = None, endpoint: str = None, verify: bool = True, algorithm: str = 'SHA256'):
         self.credentials = Credentials(dragonchain_id, auth_key, auth_key_id, algorithm)
         self.request = Request(self.credentials, endpoint, verify)
         logger.debug('Client finished initialization')
 
-    def override_credentials(self, auth_key=None, auth_key_id=None, dragonchain_id=None, update_endpoint=True):
+    def override_credentials(self, auth_key: str = None, auth_key_id: str = None, dragonchain_id: str = None, update_endpoint: bool = True):
         """Change dragonchain_id, auth_key or auth_key_id for this client
 
         Args:
@@ -44,6 +44,9 @@ class Client(object):
             auth_key_id (str, optional): The authorization key ID
             dragonchain_id (str, optional): The Dragonchain ID
             update_endpoint (bool, optional): If endpoint should automatically be updated for a new dragonchain_id
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             None, sets instance variables on credentials service
@@ -68,13 +71,18 @@ class Client(object):
 
         logger.info('Credentials updated')
 
-    def get_secret(self, secret_name):
+    def get_secret(self, secret_name: str):
         """Gets secrets for smart contracts
 
         Args:
             secret_name (str): name of the secret to retrieve
+
+        Raises:
+            TypeError with bad parameter types
+            RuntimeError if not running in a smart contract environment
+
         Returns:
-            Returns the secret from the file location
+            String of the value of the specified secret
         """
         if not isinstance(secret_name, str):
             raise TypeError('Parameter "secret_name" must be of type str.')
@@ -84,14 +92,14 @@ class Client(object):
         return open(path, 'r').read()
 
     def get_status(self):
-        """Make a PUT request to a chain
+        """Get the status from a chain
 
         Returns:
             Returns the status of a Dragonchain
         """
         return self.request.get('/status')
 
-    def query_contracts(self, query=None, sort=None, offset=0, limit=10):
+    def query_contracts(self, query: str = None, sort: str = None, offset: int = 0, limit: int = 10):
         """Perform a query on a chain's smart contracts
 
         Args:
@@ -106,12 +114,15 @@ class Client(object):
         query_params = self.request.get_lucene_query_params(query, sort, offset, limit)
         return self.request.get('/contract{}'.format(query_params))
 
-    def get_contract(self, contract_id=None, txn_type=None):
+    def get_contract(self, contract_id: str = None, txn_type: str = None):
         """Perform a query on a chain's smart contracts
 
         Args:
             contract_id (str, exclusive): Id of the contract to get
             txn_type (str, exclusive): Name of the contract to get
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             The contract returned from the request
@@ -129,20 +140,23 @@ class Client(object):
         else:
             raise TypeError('At least one of "contract_id" or "txn_type" must be specified')
 
-    def post_contract(self, txn_type, execution_order, image, cmd, args=None, env=None, secrets=None, seconds=None, cron=None, auth=None):
+    def post_contract(self, txn_type: str, execution_order: str, image: str, cmd: str, args: list = None, env: dict = None, secrets: dict = None, seconds: int = None, cron: str = None, auth: str = None):
         """Post a contract to a chain
 
         Args:
             txn_type (str): txn_type of the contract to create
-            execution_order (string): Order of execution. Valid values are 'serial' or 'parallel'
+            execution_order (str): Order of execution. Valid values are 'serial' or 'parallel'
             image (str): Docker image containing the smart contract logic
             cmd (str): Entrypoint command to run in the docker container
             args (list, optional): List of arguments to the cmd field
             env (dict, optional): dict mapping of environment variables for your contract runtime
             secrets (dict, optional): dict mapping of secrets for your contract runtime
-            seconds (string, optional): The seconds of scheduled execution in seconds
-            cron (string, optional): The rate of scheduled execution specified as a cron
-            auth (string, optional): basic-auth for pulling docker images, base64 encoded (e.g. username:password)
+            seconds (int, optional): The seconds of scheduled execution in seconds
+            cron (str, optional): The rate of scheduled execution specified as a cron
+            auth (str, optional): basic-auth for pulling docker images, base64 encoded (e.g. username:password)
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Success or failure object
@@ -189,12 +203,12 @@ class Client(object):
             body['auth'] = auth
         return self.request.post('/contract', body)
 
-    def update_contract(self, contract_id, execution_order=None, image=None, cmd=None, args=None, desired_state=None, env={}, secrets={}, seconds=None, cron=None, auth=None):
+    def update_contract(self, contract_id: str, execution_order: str = None, image: str = None, cmd: str = None, args: list = None, desired_state: str = None, env: dict = {}, secrets: dict = {}, seconds: int = None, cron: str = None, auth: str = None):
         """Update an existing smart contract. The contract_id and at least one optional parameter must be supplied.
 
         Args:
             contract_id (str): contract_id of the contract to create
-            execution_order (string): Order of execution. Valid values are 'serial' or 'parallel'
+            execution_order (str): Order of execution. Valid values are 'serial' or 'parallel'
             image (str): Docker image containing the smart contract logic
             cmd (str): Entrypoint command to run in the docker container
             args (list, optional): List of arguments to the cmd field
@@ -202,8 +216,11 @@ class Client(object):
             env (dict, optional): dict mapping of environment variables for your contract runtime
             secrets (dict, optional): dict mapping of secrets for your contract runtime
             seconds (int, optional): The seconds of scheduled execution in seconds
-            cron (string, optional): The rate of scheduled execution specified as a cron
-            auth (string, optional): basic-auth for pulling docker images, base64 encoded (e.g. username:password)
+            cron (str, optional): The rate of scheduled execution specified as a cron
+            auth (str, optional): basic-auth for pulling docker images, base64 encoded (e.g. username:password)
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Success or failure object
@@ -257,11 +274,14 @@ class Client(object):
 
         return self.request.put('/contract/{}'.format(contract_id), body)
 
-    def delete_contract(self, contract_id):
+    def delete_contract(self, contract_id: str):
         """Delete an existing contract
 
         Args:
             contract_id (str): Transaction type of the contract to delete
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             The results of the delete request
@@ -270,7 +290,7 @@ class Client(object):
             raise TypeError('Parameter "state" must be of type str.')
         return self.request.delete('/contract/{}'.format(contract_id), body={})
 
-    def query_transactions(self, query=None, sort=None, offset=0, limit=10):
+    def query_transactions(self, query: str = None, sort: str = None, offset: int = 0, limit: int = 10):
         """Perform a query on a chain's transactions
 
         Args:
@@ -285,11 +305,14 @@ class Client(object):
         query_params = self.request.get_lucene_query_params(query, sort, offset, limit)
         return self.request.get('/transaction{}'.format(query_params))
 
-    def get_transaction(self, txn_id):
+    def get_transaction(self, txn_id: str):
         """Get a specific transaction by id
 
         Args:
-            txn_id (str, uuid): ID of the transaction to get
+            txn_id (str): ID of the transaction to get (should be a UUID)
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             The transaction searched for
@@ -298,7 +321,7 @@ class Client(object):
             raise TypeError('Paramter "txn_id" must be of type str.')
         return self.request.get('/transaction/{}'.format(txn_id))
 
-    def post_transaction(self, txn_type, payload, tag=None):
+    def post_transaction(self, txn_type: str, payload, tag: str = None):
         """Post a transaction to a chain
 
         Args:
@@ -309,13 +332,16 @@ class Client(object):
         Returns:
             Transaction ID on success
         """
-        return self.request.post('/transaction', Client.build_transaction_dict(txn_type, payload, tag))
+        return self.request.post('/transaction', _build_transaction_dict(txn_type, payload, tag))
 
-    def post_transaction_bulk(self, txn_list):
+    def post_transaction_bulk(self, txn_list: list):
         """Post many transactions to a chain at once, over a single connnection
 
         Args:
             txn_list (list): List of transaction dictionaries. Schema: ``{'txn_type': 'str', 'payload': 'str or dict', 'tag': 'str (optional)'}``
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             List of succeeded transaction id's and list of failed transactions
@@ -328,30 +354,11 @@ class Client(object):
         for txn in txn_list:
             if not isinstance(txn, dict):
                 raise TypeError('All items in parameter "txn_list" must be of type dict.')
-            post_data.append(Client.build_transaction_dict(txn.get('txn_type'), txn.get('payload'), txn.get('tag')))
+            post_data.append(_build_transaction_dict(txn.get('txn_type'), txn.get('payload'), txn.get('tag')))
 
         return self.request.post('/transaction_bulk', post_data)
 
-    @staticmethod
-    def build_transaction_dict(txn_type, payload, tag=None):
-        if not isinstance(txn_type, str):
-            raise TypeError('Parameter "txn_type" must be of type str.')
-        if not isinstance(payload, str) and not isinstance(payload, dict):
-            raise TypeError('Parameter "payload" must be of type dict or str.')
-        if tag is not None and not isinstance(tag, str):
-            raise TypeError('Parameter "tag" must be of type str.')
-
-        body = {
-            'version': '1',
-            'txn_type': txn_type,
-            'payload': payload
-        }
-        if tag:
-            body['tag'] = tag
-
-        return body
-
-    def query_blocks(self, query=None, sort=None, offset=0, limit=10):
+    def query_blocks(self, query: str = None, sort: str = None, offset: int = 0, limit: int = 10):
         """Perform a query on a chain's blocks
 
         Args:
@@ -370,10 +377,13 @@ class Client(object):
         """Get a specific block by id
 
         Args:
-            block_id (int): ID of the block to get
+            block_id (str, int): ID of the block to get
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
-            The block searched for
+            The block which was retrieved from the chain
         """
         if not isinstance(block_id, str) and not isinstance(block_id, int):
             raise TypeError('Parameter "block_id" must be of type str or int.')
@@ -383,8 +393,11 @@ class Client(object):
         """Get higher level block verifications by level 1 block id
 
         Args:
-            block_id (int): ID of the block to get
-            level (int): Level of verifications to get (valid values are 2, 3, 4 and 5)
+            block_id (str, int): ID of the block to get
+            level (str, int, optional): Level of verifications to get (valid values are 2, 3, 4 and 5)
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Higher level block verifications
@@ -399,13 +412,16 @@ class Client(object):
             return self.request.get('/verifications/{}?level={}'.format(block_id, level))
         return self.request.get('/verifications/{}'.format(block_id))
 
-    def get_sc_heap(self, sc_id=None, key=None):
+    def get_sc_heap(self, sc_id: str = None, key: str = None):
         """Retrieve data from the heap storage of a smart contract
         Note: When ran in an actual smart contract, sc_id will be pulled automatically from the environment if not explicitly provided
 
         Args:
             key (str): The key stored in the heap to retrieve
             sc_id (str, optional): The ID of the smart contract, optional if called from within a smart contract
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             The value of the object in the heap
@@ -418,13 +434,17 @@ class Client(object):
             raise TypeError('Parameter "sc_id" must be of type str.')
         return self.request.get('/get/{}/{}'.format(sc_id, key), parse_response=False)
 
-    def list_sc_heap(self, sc_id=None, folder=None):
+    def list_sc_heap(self, sc_id: str = None, folder: str = None):
         """Lists all objects stored in a smart contracts heap
         Note: When ran in an actual smart contract, sc_id will be pulled automatically from the environment if not explicitly provided
 
         Args:
             sc_id (str, optional): sc_id heap to list. If not provided explicitly, it must be in the SMART_CONTRACT_NAME env var
             folder (str, optional): the folder to list in the heap. If not provided, it will default to the root of the heap
+
+        Raises:
+            TypeError with bad parameter types
+            ValueError with bad parameter values
 
         Returns:
             Parsed json response from the chain
@@ -441,7 +461,7 @@ class Client(object):
             return self.request.get('/list/{}/{}/'.format(sc_id, folder))
         return self.request.get('/list/{}/'.format(sc_id))
 
-    def create_public_blockchain_transaction(self, network, transaction):
+    def create_public_blockchain_transaction(self, network: str, transaction: dict):
         """Create and sign a public blockchain transaction using your chain's private keys
 
         Args:
@@ -471,6 +491,10 @@ class Client(object):
                     "gas": (optional, str) maximum amount of gas allowed (gasLimit), if not supplied it will be estimated for you.
                 }
 
+        Raises:
+            TypeError with bad parameter types
+            ValueError with bad parameter values
+
         Returns:
             The built and signed transaction
         """
@@ -493,15 +517,17 @@ class Client(object):
 
         Returns:
             Dictionary containing addresses
-
         """
         return self.request.get('/public-blockchain-address')
 
-    def get_transaction_type(self, transaction_type):
+    def get_transaction_type(self, transaction_type: str):
         """Gets information on a registered transaction type
 
         Args:
             transaction_type (str): transaction_type to retrieve data for
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             parsed json response of the transaction type or None
@@ -518,12 +544,15 @@ class Client(object):
         """
         return self.request.get('/transaction-types')
 
-    def update_transaction_type(self, transaction_type, custom_indexes=None):
+    def update_transaction_type(self, transaction_type: str, custom_indexes: str = None):
         """Updates the custom index of a given registered transaction type
 
         Args:
             transaction_type (str): transaction_type to update
             custom_indexes (list): custom_indexes to update
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Parsed json with success message
@@ -537,12 +566,15 @@ class Client(object):
         params = {"version": "1", "custom_indexes": custom_indexes}
         return self.request.put('/transaction-type/{}'.format(transaction_type), params)
 
-    def register_transaction_type(self, transaction_type, custom_indexes=None):
+    def register_transaction_type(self, transaction_type: str, custom_indexes: list = None):
         """Registers a new custom index
 
         Args:
             transaction_type (str): transaction_type to update
             custom_indexes (list): custom_indexes to update
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Parsed json with success message
@@ -556,11 +588,14 @@ class Client(object):
             params['custom_indexes'] = custom_indexes
         return self.request.post('/transaction-type', params)
 
-    def delete_transaction_type(self, transaction_type):
+    def delete_transaction_type(self, transaction_type: str):
         """Deletes a transaction type registration
 
         Args:
             transaction_type (str): transaction_type to delete
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Parsed json with success message
@@ -568,3 +603,35 @@ class Client(object):
         if not isinstance(transaction_type, str):
             raise TypeError('Parameter "transaction_type" must be of type str.')
         return self.request.delete('/transaction-type/{}'.format(transaction_type), body={})
+
+
+def _build_transaction_dict(txn_type: str, payload, tag: str = None):
+    """Build the json (dictionary) body for a transaction given its inputs
+
+    Args:
+        txn_type (str): The transaction type for this transaction
+        payload (str, dict): The intended payload for this transaction
+        tag (str, optional): The intended tag for this transaction
+
+    Raises:
+        TypeError with bad parameter types
+
+    Returns:
+        List of succeeded transaction id's and list of failed transactions
+    """
+    if not isinstance(txn_type, str):
+        raise TypeError('Parameter "txn_type" must be of type str.')
+    if not isinstance(payload, str) and not isinstance(payload, dict):
+        raise TypeError('Parameter "payload" must be of type dict or str.')
+    if tag is not None and not isinstance(tag, str):
+        raise TypeError('Parameter "tag" must be of type str.')
+
+    body = {
+        'version': '1',
+        'txn_type': txn_type,
+        'payload': payload
+    }
+    if tag:
+        body['tag'] = tag
+
+    return body

--- a/dragonchain_sdk/dragonchain_client.py
+++ b/dragonchain_sdk/dragonchain_client.py
@@ -46,7 +46,7 @@ class Client(object):
             update_endpoint (bool, optional): If endpoint should automatically be updated for a new dragonchain_id
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             None, sets instance variables on credentials service
@@ -78,8 +78,8 @@ class Client(object):
             secret_name (str): name of the secret to retrieve
 
         Raises:
-            TypeError with bad parameter types
-            RuntimeError if not running in a smart contract environment
+            TypeError: with bad parameter types
+            RuntimeError: if not running in a smart contract environment
 
         Returns:
             String of the value of the specified secret
@@ -122,7 +122,7 @@ class Client(object):
             txn_type (str, exclusive): Name of the contract to get
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             The contract returned from the request
@@ -156,7 +156,7 @@ class Client(object):
             auth (str, optional): basic-auth for pulling docker images, base64 encoded (e.g. username:password)
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Success or failure object
@@ -220,7 +220,7 @@ class Client(object):
             auth (str, optional): basic-auth for pulling docker images, base64 encoded (e.g. username:password)
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Success or failure object
@@ -281,7 +281,7 @@ class Client(object):
             contract_id (str): Transaction type of the contract to delete
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             The results of the delete request
@@ -312,7 +312,7 @@ class Client(object):
             txn_id (str): ID of the transaction to get (should be a UUID)
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             The transaction searched for
@@ -341,7 +341,7 @@ class Client(object):
             txn_list (list): List of transaction dictionaries. Schema: ``{'txn_type': 'str', 'payload': 'str or dict', 'tag': 'str (optional)'}``
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             List of succeeded transaction id's and list of failed transactions
@@ -380,7 +380,7 @@ class Client(object):
             block_id (str, int): ID of the block to get
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             The block which was retrieved from the chain
@@ -397,7 +397,7 @@ class Client(object):
             level (str, int, optional): Level of verifications to get (valid values are 2, 3, 4 and 5)
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Higher level block verifications
@@ -421,7 +421,7 @@ class Client(object):
             sc_id (str, optional): The ID of the smart contract, optional if called from within a smart contract
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             The value of the object in the heap
@@ -443,8 +443,8 @@ class Client(object):
             folder (str, optional): the folder to list in the heap. If not provided, it will default to the root of the heap
 
         Raises:
-            TypeError with bad parameter types
-            ValueError with bad parameter values
+            TypeError: with bad parameter types
+            ValueError: with bad parameter values
 
         Returns:
             Parsed json response from the chain
@@ -474,6 +474,7 @@ class Client(object):
                 ETC_MORDEN
 
             transaction (dict): A dictionary representing the transaction to create
+
                 BTC: {
                     "outputs": (array of {'to': str, 'value': float}, optional)
                     "fee": (optional, int) fee to pay in satoshis/byte. If not supplied, it will be estimated for you.
@@ -492,8 +493,8 @@ class Client(object):
                 }
 
         Raises:
-            TypeError with bad parameter types
-            ValueError with bad parameter values
+            TypeError: with bad parameter types
+            ValueError: with bad parameter values
 
         Returns:
             The built and signed transaction
@@ -527,7 +528,7 @@ class Client(object):
             transaction_type (str): transaction_type to retrieve data for
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             parsed json response of the transaction type or None
@@ -552,7 +553,7 @@ class Client(object):
             custom_indexes (list): custom_indexes to update
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Parsed json with success message
@@ -574,7 +575,7 @@ class Client(object):
             custom_indexes (list): custom_indexes to update
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Parsed json with success message
@@ -595,7 +596,7 @@ class Client(object):
             transaction_type (str): transaction_type to delete
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Parsed json with success message
@@ -614,7 +615,7 @@ def _build_transaction_dict(txn_type: str, payload, tag: str = None):
         tag (str, optional): The intended tag for this transaction
 
     Raises:
-        TypeError with bad parameter types
+        TypeError: with bad parameter types
 
     Returns:
         List of succeeded transaction id's and list of failed transactions

--- a/dragonchain_sdk/exceptions.py
+++ b/dragonchain_sdk/exceptions.py
@@ -22,6 +22,10 @@ class AuthorizationNotFound(DragonchainException):
     """Raised when no form of authorization can be found"""
 
 
+class MatchmakingException(DragonchainException):
+    """Raised when there is a non-200 response from the remote matchmaking service"""
+
+
 class DragonchainIdentityNotFound(DragonchainException):
     """Raised when no form of dragonchain ID can be found"""
 

--- a/dragonchain_sdk/request.py
+++ b/dragonchain_sdk/request.py
@@ -14,6 +14,7 @@ import requests
 import logging
 import urllib
 from json import dumps
+from dragonchain_sdk.configuration import get_endpoint
 from dragonchain_sdk.credentials import Credentials
 from dragonchain_sdk import exceptions
 
@@ -38,10 +39,13 @@ class Request(object):
         endpoint (str, optional): The URL for the endpoint of the chain
         verify (bool, optional): Boolean indicating whether to validate the SSL certificate of the endpoint when making requests
 
+    Raises:
+        TypeError with bad parameter types
+
     Returns:
         A new Request object.
     """
-    def __init__(self, credentials, endpoint=None, verify=True):
+    def __init__(self, credentials, endpoint: str = None, verify: bool = True):
         if isinstance(credentials, Credentials):
             self.credentials = credentials
         else:
@@ -55,24 +59,27 @@ class Request(object):
 
         self.update_endpoint(endpoint)
 
-    def update_endpoint(self, endpoint=None):
+    def update_endpoint(self, endpoint: str = None):
         """Update endpoint for this request object
 
         Args:
             endpoint (str, optional): Endpoint to set. Will auto-generate based on credentials dragonchain_id if not provided
 
+        Raises:
+            TypeError with bad parameter types
+
         Returns:
             None, sets the endpoint of this Request instance
         """
         if endpoint is None:
-            self.endpoint = 'https://{}.api.dragonchain.com'.format(self.credentials.dragonchain_id)
+            self.endpoint = get_endpoint(self.credentials.dragonchain_id)
         elif isinstance(endpoint, str):
             self.endpoint = endpoint
         else:
             raise TypeError('Parameter "endpoint" must be of type str.')
         logger.info('Target endpoint updated to {}'.format(self.endpoint))
 
-    def get(self, path, parse_response=True):
+    def get(self, path: str, parse_response: bool = True):
         """Make a GET request to a chain
 
         Args:
@@ -87,7 +94,7 @@ class Request(object):
                                   verify=self.verify,
                                   parse_response=parse_response)
 
-    def post(self, path, body, parse_response=True):
+    def post(self, path: str, body: dict, parse_response: bool = True):
         """Make a POST request to a chain
 
         Args:
@@ -104,7 +111,7 @@ class Request(object):
                                   json=body,
                                   parse_response=parse_response)
 
-    def put(self, path, body, parse_response=True):
+    def put(self, path: str, body: dict, parse_response: bool = True):
         """Make a PUT request to a chain
 
         Args:
@@ -121,7 +128,7 @@ class Request(object):
                                   json=body,
                                   parse_response=parse_response)
 
-    def delete(self, path, body, parsed_response=True):
+    def delete(self, path: str, body: dict, parsed_response: bool = True):
         """Make a DELETE request to the chain
 
         Args:
@@ -138,11 +145,15 @@ class Request(object):
                                   json=body,
                                   parse_response=parsed_response)
 
-    def get_requests_method(self, http_verb):
+    def get_requests_method(self, http_verb: str):
         """Get the appropriate requests method for a given http_verb
 
         Args:
             http_verb (str): the type of http request to make (GET, POST, etc)
+
+        Raises:
+            TypeError with bad parameter types
+            ValueError with bad parameter values
 
         Returns:
             appropriate requests http method
@@ -154,11 +165,14 @@ class Request(object):
             raise ValueError(http_verb + ' is an unsupported http operation.')
         return request_method
 
-    def generate_query_string(self, query_dict):
+    def generate_query_string(self, query_dict: dict):
         """Generate an http query string from a dictionary
 
         Args:
             query_dict (dict): dict of parameters to use in the query string
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             query string to use in an HTTP request path
@@ -174,7 +188,7 @@ class Request(object):
             # If input is empty, return an empty string as the query string
             return ''
 
-    def get_lucene_query_params(self, query=None, sort=None, offset=0, limit=10):
+    def get_lucene_query_params(self, query: str = None, sort: str = None, offset: int = 0, limit: int = 10):
         """Generate a lucene query param string with given inputs
 
         Args:
@@ -182,6 +196,9 @@ class Request(object):
             sort (str): sort syntax of 'field:direction' (e.g.: name:asc)
             offset (int): pagination offset of query
             limit (int): pagination limit
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             Query string to include in request path
@@ -202,13 +219,16 @@ class Request(object):
             params['sort'] = sort
         return self.generate_query_string(params)
 
-    def make_headers(self, timestamp, authorization, content_type=None):
+    def make_headers(self, timestamp: str, authorization: str, content_type: str = None):
         """Create a headers dictionary to send with a request to a dragonchain
 
         Args:
             timestamp (str): unix timestamp to put for this request
             content_type (str): content_type to use for this request
-            authorization (str): authorization header to include with the request
+            authorization (str, optional): authorization header to include with the request
+
+        Raises:
+            TypeError with bad parameter types
 
         Returns:
             dict of headers to use with the request
@@ -228,7 +248,7 @@ class Request(object):
             header_dict['Content-Type'] = content_type
         return header_dict
 
-    def _make_request(self, http_verb, path, json=None, timeout=30, verify=True, parse_response=True):
+    def _make_request(self, http_verb: str, path: str, json: dict = None, timeout: int = 30, verify: bool = True, parse_response: bool = True):
         """Make an http request to a dragonchain with the given information
 
         Args:
@@ -238,6 +258,12 @@ class Request(object):
             timeout (int, optional): the timeout to wait for the dragonchain to respond (defaults to 30 seconds if not set)
             verify (bool, optional): specify if the SSL cert of the chain should be verified
             parse_response (bool, optional): if the return from the chain should be parsed as json
+
+        Raises:
+            TypeError with bad parameter types
+            ValueError with bad parameter values
+            ConnectionException when unable to communicate with the dragonchain
+            UnexpectedResponseException when the dragonchain responds with an unexpected payload
 
         Returns:
             Dictionary where status is the HTTP status code, response is the return body from the chain, and ok is a boolean if the status code was in the 2XX range

--- a/dragonchain_sdk/request.py
+++ b/dragonchain_sdk/request.py
@@ -40,7 +40,7 @@ class Request(object):
         verify (bool, optional): Boolean indicating whether to validate the SSL certificate of the endpoint when making requests
 
     Raises:
-        TypeError with bad parameter types
+        TypeError: with bad parameter types
 
     Returns:
         A new Request object.
@@ -66,7 +66,7 @@ class Request(object):
             endpoint (str, optional): Endpoint to set. Will auto-generate based on credentials dragonchain_id if not provided
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             None, sets the endpoint of this Request instance
@@ -152,8 +152,8 @@ class Request(object):
             http_verb (str): the type of http request to make (GET, POST, etc)
 
         Raises:
-            TypeError with bad parameter types
-            ValueError with bad parameter values
+            TypeError: with bad parameter types
+            ValueError: with bad parameter values
 
         Returns:
             appropriate requests http method
@@ -172,7 +172,7 @@ class Request(object):
             query_dict (dict): dict of parameters to use in the query string
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             query string to use in an HTTP request path
@@ -198,7 +198,7 @@ class Request(object):
             limit (int): pagination limit
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             Query string to include in request path
@@ -228,7 +228,7 @@ class Request(object):
             authorization (str, optional): authorization header to include with the request
 
         Raises:
-            TypeError with bad parameter types
+            TypeError: with bad parameter types
 
         Returns:
             dict of headers to use with the request
@@ -260,10 +260,10 @@ class Request(object):
             parse_response (bool, optional): if the return from the chain should be parsed as json
 
         Raises:
-            TypeError with bad parameter types
-            ValueError with bad parameter values
-            ConnectionException when unable to communicate with the dragonchain
-            UnexpectedResponseException when the dragonchain responds with an unexpected payload
+            TypeError: with bad parameter types
+            ValueError: with bad parameter values
+            ConnectionException: when unable to communicate with the dragonchain
+            UnexpectedResponseException: when the dragonchain responds with an unexpected payload
 
         Returns:
             Dictionary where status is the HTTP status code, response is the return body from the chain, and ok is a boolean if the status code was in the 2XX range

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -14,7 +14,7 @@ import logging
 import dragonchain_sdk
 from unittest import TestCase
 from mock import patch, MagicMock
-from dragonchain_sdk.dragonchain_client import Client
+from dragonchain_sdk.dragonchain_client import Client, _build_transaction_dict
 
 
 @patch('dragonchain_sdk.dragonchain_client.Credentials')
@@ -114,15 +114,15 @@ class TestClientInitialization(TestCase):
 @patch('dragonchain_sdk.dragonchain_client.Request')
 @patch('dragonchain_sdk.dragonchain_client.Credentials')
 class TestClientMehods(TestCase):
-    def test_build_transaction_dict_raises_type_error(self, mock_creds, mock_request):
-        self.assertRaises(TypeError, Client.build_transaction_dict, {}, {'fake': 'payload'}, 'Tag:"value"')
-        self.assertRaises(TypeError, Client.build_transaction_dict, 'FAKETXN', [], 'Tag:"value"')
-        self.assertRaises(TypeError, Client.build_transaction_dict, 'FAKETXN', {'fake': 'payload'}, {})
+    def test__build_transaction_dict_raises_type_error(self, mock_creds, mock_request):
+        self.assertRaises(TypeError, _build_transaction_dict, {}, {'fake': 'payload'}, 'Tag:"value"')
+        self.assertRaises(TypeError, _build_transaction_dict, 'FAKETXN', [], 'Tag:"value"')
+        self.assertRaises(TypeError, _build_transaction_dict, 'FAKETXN', {'fake': 'payload'}, {})
         mock_creds.assert_not_called()
         mock_request.assert_not_called()
 
-    def test_build_transaction_dict_returns_dict(self, mock_creds, mock_request):
-        self.assertEqual(Client.build_transaction_dict('FAKETXN', {}, 'Tag:"value"'), {
+    def test__build_transaction_dict_returns_dict(self, mock_creds, mock_request):
+        self.assertEqual(_build_transaction_dict('FAKETXN', {}, 'Tag:"value"'), {
             'version': '1',
             'txn_type': 'FAKETXN',
             'payload': {},
@@ -131,8 +131,8 @@ class TestClientMehods(TestCase):
         mock_creds.assert_not_called()
         mock_request.assert_not_called()
 
-    def test_build_transaction_dict_returns_dict_no_tag(self, mock_creds, mock_request):
-        self.assertEqual(Client.build_transaction_dict('FAKETXN', {}), {
+    def test__build_transaction_dict_returns_dict_no_tag(self, mock_creds, mock_request):
+        self.assertEqual(_build_transaction_dict('FAKETXN', {}), {
             'version': '1',
             'txn_type': 'FAKETXN',
             'payload': {}

--- a/tests/unit/test_config
+++ b/tests/unit/test_config
@@ -4,3 +4,4 @@ dragonchain_id = TestID
 [TestID]
 auth_key = TestKey
 auth_key_id = TestKeyId
+endpoint = https://an.end.point

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,0 +1,193 @@
+# Copyright 2019 Dragonchain, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from mock import patch
+import requests_mock
+import os
+import configparser
+import requests
+import dragonchain_sdk.configuration as config
+from dragonchain_sdk import exceptions
+
+config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_config')
+
+
+class TestPublicConfigMethods(TestCase):
+    @patch('dragonchain_sdk.configuration._get_credentials_as_smart_contract', return_value=('', ''))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_file', return_value=('', ''))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_environment', return_value=('', ''))
+    def test_raises_on_credentials_non_existent(self, mock_get_env, mock_get_file, mock_get_sc):
+        self.assertRaises(exceptions.DragonchainIdentityNotFound, config.get_credentials, 'test')
+
+    @patch('dragonchain_sdk.configuration._get_credentials_as_smart_contract', return_value=('', ''))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_file', return_value=('', ''))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_environment', return_value=('a', 'b'))
+    def test_get_credentials_returns_from_env(self, mock_get_env, mock_get_file, mock_get_sc):
+        self.assertEqual(('a', 'b'), config.get_credentials('test'))
+        mock_get_env.assert_called_once()
+        mock_get_file.assert_not_called()
+        mock_get_sc.assert_not_called()
+
+    @patch('dragonchain_sdk.configuration._get_credentials_as_smart_contract', return_value=('', ''))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_file', return_value=('a', 'b'))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_environment', return_value=('', ''))
+    def test_get_credentials_returns_from_file(self, mock_get_env, mock_get_file, mock_get_sc):
+        self.assertEqual(('a', 'b'), config.get_credentials('test'))
+        mock_get_env.assert_called_once()
+        mock_get_file.assert_called_once_with('test')
+        mock_get_sc.assert_not_called()
+
+    @patch('dragonchain_sdk.configuration._get_credentials_as_smart_contract', return_value=('a', 'b'))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_file', return_value=('', ''))
+    @patch('dragonchain_sdk.configuration._get_credentials_from_environment', return_value=('', ''))
+    def test_get_credentials_returns_from_sc(self, mock_get_env, mock_get_file, mock_get_sc):
+        self.assertEqual(('a', 'b'), config.get_credentials('test'))
+        mock_get_env.assert_called_once()
+        mock_get_file.assert_called_once_with('test')
+        mock_get_sc.assert_called_once()
+
+    @patch('dragonchain_sdk.configuration._get_config_file_path', return_value='does_not_exist.ini')
+    def test_raises_on_dragonchain_id_non_existent(self, mock_path):
+        self.assertRaises(exceptions.DragonchainIdentityNotFound, config.get_dragonchain_id)
+
+    @patch.dict(os.environ, {'DRAGONCHAIN_ID': 'TestID'})
+    @patch('dragonchain_sdk.configuration._get_config_file_path')
+    def test_get_dragonchain_id_from_env(self, mock_path):
+        self.assertEqual('TestID', config.get_dragonchain_id())
+        mock_path.assert_not_called()
+
+    @patch('dragonchain_sdk.configuration.configparser.ConfigParser')
+    def test_get_dragonchain_id_from_file(self, mock_configparser):
+        mock_configparser.return_value.get.return_value = 'test'
+        self.assertEqual('test', config.get_dragonchain_id())
+
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_environment', return_value='')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_file', return_value='')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_remote', side_effect=exceptions.MatchmakingException)
+    def test_raises_on_endpoint_non_existent(self, mock_get_remote, mock_get_file, mock_get_env):
+        self.assertRaises(exceptions.DragonchainIdentityNotFound, config.get_endpoint, 'test')
+
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_environment', return_value='thing')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_file', return_value='')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_remote', side_effect=exceptions.MatchmakingException)
+    def test_get_endpoint_from_env(self, mock_get_remote, mock_get_file, mock_get_env):
+        self.assertEqual('thing', config.get_endpoint('test'))
+        mock_get_env.assert_called_once()
+        mock_get_file.assert_not_called()
+        mock_get_remote.assert_not_called()
+
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_environment', return_value='')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_file', return_value='thing')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_remote', side_effect=exceptions.MatchmakingException)
+    def test_get_endpoint_from_file(self, mock_get_remote, mock_get_file, mock_get_env):
+        self.assertEqual('thing', config.get_endpoint('test'))
+        mock_get_env.assert_called_once()
+        mock_get_file.assert_called_once_with('test')
+        mock_get_remote.assert_not_called()
+
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_environment', return_value='')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_file', return_value='')
+    @patch('dragonchain_sdk.configuration._get_endpoint_from_remote', return_value='thing')
+    def test_get_endpoint_from_remote(self, mock_get_remote, mock_get_file, mock_get_env):
+        self.assertEqual('thing', config.get_endpoint('test'))
+        mock_get_env.assert_called_once()
+        mock_get_file.assert_called_once_with('test')
+        mock_get_remote.assert_called_once_with('test')
+
+
+class TestPrivateConfigMethods(TestCase):
+    @patch('dragonchain_sdk.configuration._get_config_file_path', return_value=config_file)
+    def test_gets_endpoint_from_config_file(self, mock_path):
+        self.assertEqual('https://an.end.point', config._get_endpoint_from_file('TestID'))
+
+    @patch('dragonchain_sdk.configuration.configparser.ConfigParser')
+    def test_gets_endpoint_from_file_returns_empty_on_no_section(self, mock_configparser):
+        mock_configparser.return_value.get.side_effect = configparser.NoSectionError('test')
+        self.assertEqual('', config._get_endpoint_from_file('test'))
+
+    @patch('dragonchain_sdk.configuration.configparser.ConfigParser')
+    def test_gets_endpoint_from_file_returns_empty_on_no_option(self, mock_configparser):
+        mock_configparser.return_value.get.side_effect = configparser.NoOptionError('test', 'test')
+        self.assertEqual('', config._get_endpoint_from_file('test'))
+
+    @patch('dragonchain_sdk.configuration._get_config_file_path', return_value=config_file)
+    def test_gets_credentials_from_config_file(self, mock_path):
+        self.assertEqual(('TestKeyId', 'TestKey'), config._get_credentials_from_file('TestID'))
+
+    @patch('dragonchain_sdk.configuration.configparser.ConfigParser')
+    def test_gets_credentials_from_file_returns_empty_on_no_section(self, mock_configparser):
+        mock_configparser.return_value.get.side_effect = configparser.NoSectionError('test')
+        self.assertEqual(('', ''), config._get_credentials_from_file('test'))
+
+    @patch('dragonchain_sdk.configuration.configparser.ConfigParser')
+    def test_gets_credentials_from_file_returns_empty_on_no_option(self, mock_configparser):
+        mock_configparser.return_value.get.side_effect = configparser.NoOptionError('test', 'test')
+        self.assertEqual(('', ''), config._get_credentials_from_file('test'))
+
+    @patch.dict(os.environ, {'AUTH_KEY': 'TestKey', 'AUTH_KEY_ID': 'TestKeyId'})
+    def test_gets_credentials_from_environ(self):
+        self.assertEqual(('TestKeyId', 'TestKey'), config._get_credentials_from_environment())
+
+    @patch.dict(os.environ, {'DRAGONCHAIN_ENDPOINT': 'dummy'})
+    def test_gets_endpoint_from_environ(self):
+        self.assertEqual('dummy', config._get_endpoint_from_environment())
+
+    @patch('dragonchain_sdk.configuration.open')
+    def test_gets_credentials_from_smart_contract(self, mock_open):
+        mock_open.return_value.read.return_value = 'bogusAuth'
+        self.assertEqual(config._get_credentials_as_smart_contract(), ('bogusAuth', 'bogusAuth'))
+
+    @patch('dragonchain_sdk.configuration.open')
+    def test_gets_credentials_from_smart_contract_catches_filenotfound(self, mock_open):
+        mock_open.side_effect = FileNotFoundError()
+        self.assertEqual(('', ''), config._get_credentials_as_smart_contract())
+
+    @patch('dragonchain_sdk.configuration.requests.get', side_effect=requests.ConnectionError)
+    def test_gets_credentials_from_remote_raises_with_communication_error(self, mock_request):
+        self.assertRaises(exceptions.MatchmakingException, config._get_endpoint_from_remote, 'test')
+
+    @patch('dragonchain_sdk.configuration.requests.get', side_effect=Exception)
+    def test_gets_credentials_from_remote_raises_with_unknown_requests_error(self, mock_request):
+        self.assertRaises(exceptions.MatchmakingException, config._get_endpoint_from_remote, 'test')
+
+    def test_gets_credentials_from_remote_raises_with_404(self):
+        with requests_mock.mock() as m:
+            m.get('https://matchmaking.api.dragonchain.com/registration/test', status_code=404, text='{"error": "some error"}')
+            self.assertRaises(exceptions.MatchmakingException, config._get_endpoint_from_remote, 'test')
+
+    def test_gets_credentials_from_remote_raises_with_bad_response_data_from_matchmaking(self):
+        with requests_mock.mock() as m:
+            m.get('https://matchmaking.api.dragonchain.com/registration/test', status_code=200, text='{"error": "some error"}')
+            self.assertRaises(exceptions.MatchmakingException, config._get_endpoint_from_remote, 'test')
+
+    def test_gets_credentials_from_remote_returns_url_from_matchmaking(self):
+        with requests_mock.mock() as m:
+            m.get('https://matchmaking.api.dragonchain.com/registration/test', status_code=200, text='{"url": "dummy"}')
+            self.assertEqual('dummy', config._get_endpoint_from_remote('test'))
+
+    @patch('os.path.join', return_value='full path')
+    @patch('os.path.expandvars', return_value='expanded')
+    def test_get_config_file_path_windows(self, mock_expand, mock_join):
+        os.name = 'nt'
+        self.assertEqual(config._get_config_file_path(), 'full path')
+        mock_expand.assert_called_once_with('%LOCALAPPDATA%')
+        mock_join.assert_called_once_with('expanded', 'dragonchain', 'credentials')
+
+    @patch('os.path.join', return_value='full path')
+    @patch('os.path.expandvars', return_value='expanded')
+    @patch('os.path.expanduser', return_value='home')
+    def test_get_config_file_path_posix(self, mock_home, mock_expand, mock_join):
+        os.name = 'posix'
+        self.assertEqual(config._get_config_file_path(), 'full path')
+        mock_home.assert_called_once()
+        mock_expand.assert_not_called()
+        mock_join.assert_called_once_with('home', '.dragonchain', 'credentials')


### PR DESCRIPTION
Dragonchains will be moving to a different id scheme soon. Previously the SDK assumed a URL based off of the dragonchain ID, which isn't relevant anymore. This PR includes changes so that the endpoint for a dragonchain can be set with more configuration options, as well as dynamically fetching it from a remote service if not found.

This should be fully forward/backwards compatible with no breaking changes.